### PR TITLE
Rename Buffer.AddAt to Insert.

### DIFF
--- a/edit/buffer/buffer.go
+++ b/edit/buffer/buffer.go
@@ -100,11 +100,11 @@ func (b *Buffer) ReadAt(bs []byte, q int64) (int, error) {
 	return n, nil
 }
 
-// AddAt adds the bytes to the address in the Buffer.
+// Insert adds the bytes to the address in the Buffer.
 // After adding, the byte at the address is the first of the added bytes.
 // The return value is the number of bytes added and any error that was encountered.
 // It is an error to add at a negative address or an address that is greater than the Buffer size.
-func (b *Buffer) AddAt(bs []byte, q int64) (int, error) {
+func (b *Buffer) Insert(bs []byte, q int64) (int, error) {
 	if q < 0 || q > b.Size() {
 		return 0, ErrBadAddress
 	}

--- a/edit/buffer/buffer_test.go
+++ b/edit/buffer/buffer_test.go
@@ -15,14 +15,14 @@ func TestReadAt(t *testing.T) {
 	b := New(testBlockSize)
 	defer b.Close()
 	// Add 3 full blocks.
-	n, err := b.AddAt([]byte("01234567abcdefghSTUVWXYZ"), 0)
+	n, err := b.Insert([]byte("01234567abcdefghSTUVWXYZ"), 0)
 	if n != 24 || err != nil {
-		t.Fatalf(`AddAt("01234567abcdefghSTUVWXYZ", 0)=%v,%v, want 24,nil`, n, err)
+		t.Fatalf(`Insert("01234567abcdefghSTUVWXYZ", 0)=%v,%v, want 24,nil`, n, err)
 	}
 	// Split block 1 in the middle.
-	n, err = b.AddAt([]byte("!@#"), 12)
+	n, err = b.Insert([]byte("!@#"), 12)
 	if n != 3 || err != nil {
-		t.Fatalf(`AddAt("!@#", 12)=%v,%v, want 3,nil`, n, err)
+		t.Fatalf(`Insert("!@#", 12)=%v,%v, want 3,nil`, n, err)
 	}
 	ns := make([]int, len(b.blocks))
 	for i, blk := range b.blocks {
@@ -73,7 +73,7 @@ func TestReadAt(t *testing.T) {
 	}
 }
 
-func TestAddAt(t *testing.T) {
+func TestInsert(t *testing.T) {
 	tests := []struct {
 		init, add string
 		at        int64
@@ -115,20 +115,20 @@ func TestAddAt(t *testing.T) {
 		b := New(testBlockSize)
 		defer b.Close()
 		if len(test.init) > 0 {
-			n, err := b.AddAt([]byte(test.init), 0)
+			n, err := b.Insert([]byte(test.init), 0)
 			if n != len(test.init) || err != nil {
-				t.Errorf("%+v init failed: AddAt(%v, 0)=%v,%v, want %v,nil",
+				t.Errorf("%+v init failed: Insert(%v, 0)=%v,%v, want %v,nil",
 					test, test.init, n, err, len(test.init))
 				continue
 			}
 		}
-		n, err := b.AddAt([]byte(test.add), test.at)
+		n, err := b.Insert([]byte(test.add), test.at)
 		wantn := len(test.add)
 		if test.err != nil {
 			wantn = 0
 		}
 		if n != wantn || err != test.err {
-			t.Errorf("%+v add failed: AddAt(%v, %v)=%v,%v, want %v,%v",
+			t.Errorf("%+v add failed: Insert(%v, %v)=%v,%v, want %v,%v",
 				test, test.add, test.at, n, err, wantn, test.err)
 			continue
 		}


### PR DESCRIPTION
When editing text, you insert and delete, you don't add and remove.
As evidence, look down at your keyboard. Find the insert and delete keys.
Now look again and find the add and remove keys.
Also, insert and delete have the same number of letters,
but remove is twice as long as add.

I also excluded the At suffix.
ReadAt implements the io.ReaderAt interface.
There are no InserterAt or DeleterAt interfaces.
