### PR TITLE
Initialize subexpression matches when re-using the start state.

### DIFF
--- a/re1/re1.go
+++ b/re1/re1.go
@@ -607,6 +607,9 @@ func (m *mach) match() [][2]int64 {
 		return nil
 	}
 	m.open[0].n = m.re.start
+	for i := range m.open[0].es {
+		m.open[0].es[i] = [2]int64{}
+	}
 	nopen := 1
 	for {
 		nclosed := m.εclose(p, c, nopen)

--- a/re1/re1_test.go
+++ b/re1/re1_test.go
@@ -299,6 +299,27 @@ func TestMatch(t *testing.T) {
 	}
 }
 
+func TestReuse(t *testing.T) {
+	re, err := Compile([]rune("(a)(b)(c)|(x)(y)(z)"), Options{})
+	if err != nil {
+		t.Fatalf(`Compile("(a)(b)(c)|(x)(y)(z)")=%v, want nil`, err)
+	}
+	str := "abc"
+	want := []string{"abc", "a", "b", "c", "", "", ""}
+	got := matches(str, re.Match(sliceRunes([]rune(str)), 0), false)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf(`Compile("(a)(b)(c)|(x)(y)(z)").Match(%s)=%v, want %v`, str, got, want)
+	}
+	// This will get different subexpression matches.
+	// Make sure that there isn't old data from the previous match.
+	str = "xyz"
+	want = []string{"xyz", "", "", "", "x", "y", "z"}
+	got = matches(str, re.Match(sliceRunes([]rune(str)), 0), false)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf(`Compile("(a)(b)(c)|(x)(y)(z)").Match(%s)=%v, want %v`, str, got, want)
+	}
+}
+
 type sliceRunes []rune
 
 func (s sliceRunes) Rune(i int64) rune { return s[i] }


### PR DESCRIPTION
The expression matches are copied to subsequent states, so they don't need to be initialized, just the first.
